### PR TITLE
add Use role post connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,18 @@ or
      "user": "my_user",
      "password": "password",
      "warehouse": "my_virtual_warehouse",
+     "role": "my_optional_role",
      "tables": "db.schema.table1,db.schema.table2"
    }
    ```
 
-**Note**: `tables` is a mandatory parameter as well to avoid long running catalog discovery process.
+**Note1**: `tables` is a mandatory parameter as well to avoid long running catalog discovery process.
 Please specify fully qualified table and view names and only that ones that you need to extract otherwise you can
 end up with very long running discovery mode of this tap. Discovery mode is analysing table structures but
 Snowflake doesn't like selecting lot of rows from `INFORMATION_SCHEMA` or running `SHOW` commands that returns lot of
 rows. Please be as specific as possible.
+
+**Note2**: `role` is optional. Use when wanting to connect to a role that is not set as the default role for the user.
 
 2. Run it in discovery mode to generate a `properties.json`
 

--- a/tap_snowflake/connection.py
+++ b/tap_snowflake/connection.py
@@ -66,7 +66,7 @@ class SnowflakeConnection:
 
     def open_connection(self):
         """Connect to snowflake database"""
-        return snowflake.connector.connect(
+        conn_obj = snowflake.connector.connect(
             user=self.connection_config['user'],
             password=self.connection_config['password'],
             account=self.connection_config['account'],
@@ -76,6 +76,13 @@ class SnowflakeConnection:
             # Use insecure mode to avoid "Failed to get OCSP response" warnings
             # insecure_mode=True
         )
+        if self.connection_config['role'] is None:
+            return conn_obj
+        else:
+            sql = 'USE ROLE {}'.format(self.connection_config['role'])
+            cursor_obj = conn_obj.cursor()
+            cursor_obj.execute(sql)
+            return conn_obj
 
     @retry_pattern()
     def connect_with_backoff(self):


### PR DESCRIPTION
add an optional meltano config for a role that can be used after connection to facilitate using a snowflake role not associated with the default role.